### PR TITLE
Make sure zf-matcher loads zf native library.

### DIFF
--- a/lua/fuzzy_nvim/zf_matcher.lua
+++ b/lua/fuzzy_nvim/zf_matcher.lua
@@ -1,4 +1,5 @@
 local zf = require('zf')
+zf.load_zf()
 
 local M = {}
 


### PR DESCRIPTION
Sorry, I forget to add `load_zf()` to zf-matcher. The zf native library was loaded by telescope by my nvim config.